### PR TITLE
cpu.c: Build cpu.c without any assumptions about CPU flags

### DIFF
--- a/lib/automake.mk
+++ b/lib/automake.mk
@@ -36,8 +36,6 @@ lib_libopenvswitchavx512_la_CFLAGS = \
 	-fPIC \
 	$(AM_CFLAGS)
 lib_libopenvswitchavx512_la_SOURCES = \
-	lib/cpu.c \
-	lib/cpu.h \
 	lib/dpif-netdev-avx512.c
 if HAVE_AVX512BW
 lib_libopenvswitchavx512_la_CFLAGS += \
@@ -98,6 +96,8 @@ lib_libopenvswitch_la_SOURCES = \
 	lib/csum.h \
 	lib/ct-dpif.c \
 	lib/ct-dpif.h \
+	lib/cpu.c \
+	lib/cpu.h \
 	lib/daemon.c \
 	lib/daemon.h \
 	lib/daemon-private.h \


### PR DESCRIPTION
The cpu.c was built with multiple feature flags that might
not be available on all hosts. It manifested itself as
Illegal instruction with crashing on "shlx" instruction
which is part of the bmi2 extension, that might not be available
on all CPU that openvswitch runs on.

Move the cpu.c and cpu.h to lib_libopenvswitch_la_SOURCES which
should build it without any assumptions about CPU capabilities.

Fixes: b366fa2f494 ("dpif-netdev: Call cpuid for x86 isa availability. ")
Reported-at: https://bugzilla.redhat.com/2100393
Signed-off-by: Ales Musil <amusil@redhat.com>